### PR TITLE
fix: Replace space (` `) with dashes (`-`) in vim color scheme names

### DIFF
--- a/internal/vim/vim.go
+++ b/internal/vim/vim.go
@@ -124,8 +124,8 @@ func getVimColorSchemeName(fileContent *string) (string, error) {
 		return "", errors.New("no vim color scheme match")
 	}
 
-	expression := regexp.MustCompile(`[() ]`)
-	cleanedName := expression.ReplaceAllString(matches[2], "")
+	cleanedName := regexp.MustCompile(`[()]`).ReplaceAllString(matches[2], "")
+	cleanedName = regexp.MustCompile(` `).ReplaceAllString(cleanedName, "-")
 
 	return strings.ToLower(cleanedName), nil
 }

--- a/internal/vim/vim_test.go
+++ b/internal/vim/vim_test.go
@@ -176,8 +176,12 @@ func TestGetColorSchemeName(t *testing.T) {
 		syntex reset`, name: "hello_world"},
 		{fileContent: `
 		hi clear
+		let g:color_name="hello world"
+		syntex reset`, name: "hello-world"},
+		{fileContent: `
+		hi clear
 		let g:color_name="hello (world)"
-		syntex reset`, name: "helloworld"},
+		syntex reset`, name: "hello-world"},
 		{fileContent: `
 		hi clear
 		let colors_name = "abcd1234"


### PR DESCRIPTION
Fixes https://github.com/vimcolorschemes/vimcolorschemes/issues/812

Replicates what vim does natively.

Example: A color scheme named "Night coder" will be accessible through the following configuration:

```vim
colorscheme night-coder
```