### PR TITLE
feat: Install lush.nvim on neovim instance

### DIFF
--- a/cli/generate.go
+++ b/cli/generate.go
@@ -209,6 +209,11 @@ func setupVim() {
 	if err != nil {
 		log.Panic(err)
 	}
+
+	err = installPlugin("https://github.com/rktjmp/lush.nvim", "lush.nvim")
+	if err != nil {
+		log.Panic(err)
+	}
 }
 
 // Installs a plugin/color scheme on the vim configuration from a GitHub URL


### PR DESCRIPTION
Closes https://github.com/vimcolorschemes/vimcolorschemes/issues/898

lush.nvim is used as base for some color schemes.